### PR TITLE
solved footer text alignment problem

### DIFF
--- a/index.html
+++ b/index.html
@@ -1352,7 +1352,7 @@
 								<li><i class="icon pe-7s-mail"></i><span><a href="mailto:fossasia@googlegroups.com" target="_self" style="color:#777777">fossasia@googlegroups.com</a></span></li>
 								<li><i class="icon pe-7s-phone"></i><span>+65 83435672</span></li>
 								<li><i class="icon pe-7s-map-marker"></i><span>Ms. DANG Hong Phuc</span>
-								<span></span>FOSSASIA Xoai Building, 93 Mau Than Street Xuan Khan, Ninh Kieu 9000 Can Tho, Vietnam</span></li>
+								<span></span><br />FOSSASIA Xoai Building, 93 Mau Than Street Xuan Khan, Ninh Kieu 9000 Can Tho, Vietnam</span></li>
 							</ul>
 						</div>
 					</div>

--- a/index.html
+++ b/index.html
@@ -1350,7 +1350,7 @@
 						<div class="col-sm-3">
 							<ul class="contact-methods">
 								<li><i class="icon pe-7s-mail"></i><span><a href="mailto:fossasia@googlegroups.com" target="_self" style="color:#777777">fossasia@googlegroups.com</a></span></li>
-								<li><i class="icon pe-7s-phone"></i><span>+65 83435672</span></li>
+								<li><i class="icon pe-7s-phone"></i><span><a href="callto:+6583435672">+65 83435672</a></span></li>
 								<li><i class="icon pe-7s-map-marker"></i><span>Ms. DANG Hong Phuc</span>
 								<span></span><br />FOSSASIA Xoai Building, 93 Mau Than Street Xuan Khan, Ninh Kieu 9000 Can Tho, Vietnam</span></li>
 							</ul>


### PR DESCRIPTION
In the right bottom of the website footer the text "FOSSASIA Xoai Building, 93 Mau Than Street Xuan Khan, Ninh Kieu 9000 Can Tho, Vietnam" is overlapping the text "Ms. DANG Hong Phuc"

Before:
![screenshot from 2017-07-24 14-23-00](https://user-images.githubusercontent.com/17426705/28515627-f62c940a-707b-11e7-8a46-24a4405feb57.png)

After:
![screenshot from 2017-07-24 14-23-17](https://user-images.githubusercontent.com/17426705/28515667-17555838-707c-11e7-8590-315d88046b82.png)
